### PR TITLE
Add support for disabling multi-packet responses

### DIFF
--- a/config.c
+++ b/config.c
@@ -13,6 +13,7 @@
  */
 #define CONFIG_KEY_SERVICE  "port"
 #define CONFIG_KEY_PASSWORD "password"
+#define CONFIG_KEY_SINGLE_PACKET "single_packet"
 
 static GKeyFile *config = NULL;
 
@@ -48,9 +49,11 @@ void config_free(void)
 }
 
 int config_host_data(char const *name, char **hostname,
-                     char **service, char **passwd)
+                     char **service, char **passwd,
+                    int *single_packet_mode)
 {
     gchar *h = NULL, *s = NULL, *p = NULL;
+    bool single_packet;
     return_if_true(config == NULL, -1);
 
     if (!g_key_file_has_group(config, name)) {
@@ -73,6 +76,9 @@ int config_host_data(char const *name, char **hostname,
     if (hostname) {
         *hostname = strdup(h);
     }
+
+    single_packet = g_key_file_get_boolean(config, name, CONFIG_KEY_SINGLE_PACKET, NULL);
+    *single_packet_mode = (single_packet ? 1 : 0);
 
     if (service) {
         *service = strdup(s);

--- a/config.h
+++ b/config.h
@@ -5,6 +5,6 @@ extern void config_free(void);
 extern int config_load(char const *file);
 
 extern int config_host_data(char const *name, char **hostname,
-                            char **port, char **passwd);
+                            char **port, char **passwd, int *single_packet_mode);
 
 #endif

--- a/rcon.bashcomp.sh
+++ b/rcon.bashcomp.sh
@@ -6,8 +6,8 @@ _rcon()
 
     _init_completion || return
 
-    lngopts="--config --help --host --port --password --server"
-    shtopts="-c -H -h -p -P -s"
+    lngopts="--config --help --host --port --password --server --1packet"
+    shtopts="-c -H -h -p -P -s -1"
     configfile="$HOME/.rconrc"
 
     case "${prev}" in

--- a/srcrcon.h
+++ b/srcrcon.h
@@ -34,13 +34,15 @@ extern rcon_error_t src_rcon_command_wait(src_rcon_t *r,
                                           src_rcon_message_t const *cmd,
                                           src_rcon_message_t ***replies,
                                           size_t *off, void const *buf,
-                                          size_t size);
+                                          size_t size,
+                                          int single_packet_mode);
 
 extern src_rcon_message_t *src_rcon_auth(src_rcon_t *r, char const *password);
 extern rcon_error_t src_rcon_auth_wait(src_rcon_t *r,
                                        src_rcon_message_t const *auth,
                                        size_t *off,
-                                       void const *buf, size_t sz);
+                                       void const *buf, size_t sz,
+                                       int single_packet_mode);
 
 extern rcon_error_t src_rcon_serialize(src_rcon_t *r,
                                        src_rcon_message_t const *m,


### PR DESCRIPTION
Some servers (e.g. Factorio) don't implement the trick of adding a
0-length SERVERDATA_RESPONSE_VALUE message at the end of messages
because they never try to send multi-packet responses. This commit adds
a new flag that effectively disables any expectation of multi-packet
responses, and in particular makes it possible to use it with the
headless Factorio server (as of versions <= 0.15).


Possibly also the problem experienced in #4 ?