### PR TITLE
Package rcon using CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ ADD_SUBDIRECTORY(tests)
 # CPack
 # Common variables to all packagers
 set(CPACK_PACKAGE_NAME "rcon")
-set(CPACK_PACKAGE_VERSION "1.0.0")
+set(CPACK_PACKAGE_VERSION "0.6")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A source RCON client, sends commands to a server and prints the reply to stdout.")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/n0la/rcon")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/description.txt")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/description.txt")
 
 # RPM (RHEL-based distros) - Use -DCMAKE_BINARY_RPM=ON flag to enable it
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
-set(CPACK_RPM_PACKAGE_LICENSE "BSD")
+set(CPACK_RPM_PACKAGE_LICENSE "BSD-2-Clause")
 
 # DEB (Debian-based distros) - Use -DCMAKE_BINARY_DEB=ON flag to enable it
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,5 @@ set(CPACK_RPM_PACKAGE_LICENSE "BSD-2-Clause")
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "$ENV{USER}")
 
-## Windows - Use WiX tools with the flag -DCPACK_GENERATOR=WIX
-#if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-#	set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/assets\\\\logo.png")
-#	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/assets/LICENSE.txt")
-#endif()
-
 # Use CPack
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,3 +75,28 @@ ENDIF()
 
 ENABLE_TESTING()
 ADD_SUBDIRECTORY(tests)
+
+# CPack
+# Common variables to all packagers
+set(CPACK_PACKAGE_NAME "rcon")
+set(CPACK_PACKAGE_VERSION "1.0.0")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A source RCON client, sends commands to a server and prints the reply to stdout.")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/n0la/rcon")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/description.txt")
+
+# RPM (RHEL-based distros) - Use -DCMAKE_BINARY_RPM=ON flag to enable it
+set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
+set(CPACK_RPM_PACKAGE_LICENSE "BSD")
+
+# DEB (Debian-based distros) - Use -DCMAKE_BINARY_DEB=ON flag to enable it
+set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "$ENV{USER}")
+
+## Windows - Use WiX tools with the flag -DCPACK_GENERATOR=WIX
+#if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+#	set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/assets\\\\logo.png")
+#	set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/assets/LICENSE.txt")
+#endif()
+
+# Use CPack
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ the cmake command line:
 $ cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DINSTALL_BASH_COMPLETION=ON
 ```
 
+## Installation through your package manager
+
+You need the same dependencies as with the manual installation. But the steps
+are a little different:
+
+1. Create the build directory:
+    ```shell
+    $ mkdir build
+    $ cd build
+    ```
+2. Configure the build system:
+    - If you're on a debian-based distro:
+        ```shell
+        $ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BINARY_DEB=ON
+        ```
+    - If you're on a RHEL based distro:
+        ```shell
+        $ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BINARY_RPM=ON
+        ```
+3. Build and package the project:
+    ```shell
+    $ cmake --build . --target package
+    ```
+4. Install the package with your package manager, you'll find the file in the build folder.
+
+Remember to use `-DINSTALL_BASH_COMPLETION=ON` on the second step if you also
+want the bash completion script to be installed.
+
 # Documentation
 
 The utility comes with a man page: ```rcon(1)```. View it with:

--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,1 @@
+rcon is a command line application that can be used as a Source RCON client. It will send commands to the given server, and print the reply to stdout.


### PR DESCRIPTION
[CPack](https://cmake.org/cmake/help/latest/module/CPack.html) comes with CMake and it allows you to create convenient packages to install the software.

I added instructions to the CMakeLists.txt to package rcon in **.deb**, **.rpm**, and **.tar.gz** formats. Also added instructions on how to do it from the command line in the README.

There's one more file I added: *description.txt*, it's a single line file used to provide a description in .rpm packages.

Using packages like this also provides users with an option to uninstall the package in one command, should they want to do so.